### PR TITLE
Query default changeset, not tip

### DIFF
--- a/trains.js
+++ b/trains.js
@@ -1,5 +1,5 @@
 /*global gapi,XDomainRequest */
-var URL = ["https://hg.mozilla.org/", "/raw-file/tip/config/milestone.txt"];
+var URL = ["https://hg.mozilla.org/", "/raw-file/default/config/milestone.txt"];
 var BRANCHES = [
   ["release", "releases/mozilla-release"],
   ["beta", "releases/mozilla-beta"],


### PR DESCRIPTION
Querying the "tip" changeset returns the changeset that was last committed to the repository.

At this exact moment in time, "tip" of mozilla-aurora is 31ec81b5d7bb, which is a closure on a very old branch - one from Firefox 18. This is causing Developer Edition to be reported as Firefox 18. Switching to "default" will select the most recent commit on the "default" branch, which properly returns f915102fc4b3, which is a modern commit.
